### PR TITLE
Replace GNU grep use with POSIX-compliant grep/sed use

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: scan-with-appsweep
-  - BITRISE_STEP_VERSION: "2.0.0"
+  - BITRISE_STEP_VERSION: "2.0.1"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
 

--- a/step.sh
+++ b/step.sh
@@ -78,7 +78,7 @@ else
     output=$($GRADLEW uploadToAppSweepRelease)
 fi
 
-url=$(echo $output | grep -oP '(?<=Your scan results will be available at )[^ ]*' )
+url=$(echo $output | grep 'Your scan results will be available at' | sed 's/.*Your scan results will be available at //')
 
 envman add --key APPSWEEP_UPLOAD_URL --value $url
 echo "APPSWEEP_UPLOAD_URL=$url"


### PR DESCRIPTION
This replaces a non-POSIX-compliant use of GNU `grep` with a compliant combination of `grep` and `sed`.
Tested online, see screenshot below:
![bitrise2](https://github.com/Guardsquare/bitrise-step-scan-with-appsweep/assets/153075898/c4fedd44-2f7c-4168-8119-8f1b7f9213be)

(Test app upload, the build URL isn't considered secret)