### PR TITLE
Add support for custom Gradle build variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upload build to AppSweep
 
-The step uploads a release or debug build to [AppSweep](https://appsweep.guardsquare.com) for security scanning. Itsupports iOS and Android apps.
+The step uploads a release or debug build to [AppSweep](https://appsweep.guardsquare.com) for security scanning. It supports iOS and Android apps.
 
 The AppSweep Gradle plugin is used to upload your Android app, while the [Guardsquare CLI](https://appsweep.guardsquare.com/docs/ci/guardsquare-cli) is used for iOS.
 
@@ -18,8 +18,8 @@ See below for the platform-specific configuration.
 To use this step, you need:
 
 * A [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) in your project. It is expected in the root folder.
-* The Gradle AppSweep plugin. If you have a common folder structre (in particular `./app/build.gradle` is your app's gradle file) then the plugin will be injected automatically. Otherwise you need to add the AppSweep plugin manually, by adding `id "com.guardsquare.appsweep" version "latest.release"` to the plugin section of your app's build.gradle script.
-* By default the `release` build will be scanned. If you want to change this, set `build_variant: debug` in your steps configuration.
+* The Gradle AppSweep plugin. If you have a common folder structure (in particular `./app/build.gradle` is your app's gradle file) then the plugin will be injected automatically. Otherwise you need to add the AppSweep plugin manually, by adding `id "com.guardsquare.appsweep" version "latest.release"` to the plugin section of your app's build.gradle script.
+* By default, the `release` build will be scanned. If you want to change this, set `build_variant` to the desired variant in your step's configuration.
 
 ### iOS
 
@@ -33,7 +33,7 @@ The step can either be configured directly in the `bitrise.yml`, or in the visua
 | Platform | Parameter         | Default     | Description |
 |----------|-------------------|-------------|-------------|
 | both | appsweep_api_key| `APPSWEEP_API_KEY` secret key | Must be set to allow scanning of the app inside an AppSweep project. You can generate it in the API Keys section of your project settings in the AppSweep UI.| 
-| Android | build_variant | release | Set to `debug` to upload the debug version of your app, or to `release` to upload the release version. |
+| Android | build_variant | release | Set to the desired build variant name for variants other than `release`. |
 | Android | project_location | `$PROJECT_LOCATION` | Set this to the location of your project inside your repository. Inside this directory, the build file should be accesible via path ./app/build.gradle and ./gradlew should be directly in the project_location. If your project has a traditional structure, the default value should be correct.|
 | Android | gradle_plugin_version | `1.0.0` | Set to particular numerical value or to `latest.release` (requires at least Gradle 7). If the plugin is already configured in your repository then this option has no impact.|
 | iOS | ios_archive_path | `$BITRISE_XCARCHIVE_PATH` | Path to either the IPA file or the xcarchive directory (not a zip file). |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: scan-with-appsweep
-  - BITRISE_STEP_VERSION: "2.0.1"
+  - BITRISE_STEP_VERSION: "2.0.2"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
 

--- a/step.sh
+++ b/step.sh
@@ -71,11 +71,16 @@ else
 	echo "The gradlew wrapper was not found. Please provide the correct project_location."
 	exit 1
 fi
-if [ "${build_variant}" = "debug" ]
+
+basename="uploadToAppSweep"
+if [ -z "${build_variant+x}" ];
 then
-	output=$($GRADLEW uploadToAppSweepDebug)
+  # Build variant absent, we default to release
+  output=$($GRADLEW "${basename}Release")
 else
-    output=$($GRADLEW uploadToAppSweepRelease)
+  # Capitalize first letter of variant name, concatenate with Gradle task basename
+  capitalized="$(echo ${build_variant} | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')"
+  output=$($GRADLEW "$basename$capitalized")
 fi
 
 url=$(echo $output | grep 'Your scan results will be available at' | sed 's/.*Your scan results will be available at //')

--- a/step.sh
+++ b/step.sh
@@ -73,7 +73,7 @@ else
 fi
 
 basename="uploadToAppSweep"
-if [ -z "${build_variant+x}" ];
+if [ -z "${build_variant}" ];
 then
   # Build variant absent, we default to release
   output=$($GRADLEW "${basename}Release")

--- a/step.yml
+++ b/step.yml
@@ -56,13 +56,10 @@ inputs:
 - build_variant: release
   opts:
     description: |
-      Set to `debug` to upload the debug version of your app, or to `release` to upload the release version.
+      Set to the desired build variant, e.g. `debug`. By default, the `release` variant will be uploaded.
     is_required: false
     title: Select the build variant which should be uploaded
     category: "Android"
-    value_options:
-    - debug
-    - release
 - project_location: $PROJECT_LOCATION
   opts:
     description: |
@@ -70,7 +67,6 @@ inputs:
     is_required: false
     title: Project file path
     category: "Android"
-  project_location: $PROJECT_LOCATION
 - gradle_plugin_version: 1.0.0
   opts:
     description: |


### PR DESCRIPTION
This adds support for custom Gradle build variants by computing the AppSweep task name based on the `build_variant` input parameter in the same way as the AppSweep Gradle plugin. If the variable is unset, we default to `release`, as previously.

Testing screenshot:
![upload_custom_task_name](https://github.com/Guardsquare/bitrise-step-scan-with-appsweep/assets/153075898/eeebe37b-ee69-455d-99cc-c156f456cd84)