### PR TITLE
Use the Guardsquare CLI also for Android apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upload build to AppSweep
 
-The step uploads a built app to [AppSweep](https://appsweep.guardsquare.com) for security scanning. It supports iOS and Android apps, and uses the [Guardsquare CLI](https://appsweep.guardsquare.com/docs/ci/guardsquare-cli) to upload the app
+The step uploads a built app to [AppSweep](https://appsweep.guardsquare.com) for security scanning. It supports iOS and Android apps, and uses the [Guardsquare CLI](https://appsweep.guardsquare.com/docs/ci/guardsquare-cli) to upload the app.
 
 ## How to use this Step
 
@@ -22,7 +22,6 @@ The step can either be configured directly in the `bitrise.yml`, or in the visua
 | Android | android_app_path | `$BITRISE_APK_PATH` | Path name to the built Android app. Can be an Android apk / aab. |
 | Android | android_mappingfile_path | `$BITRISE_MAPPING_PATH` | Path to the obfuscation mapping file. E.g., ./app/build/outputs/mapping/debug/mapping.txt |
 | Android | android_project_location | `$PROJECT_LOCATION` | Set this to the location of your project inside your repository. Inside this directory, the build file should be accesible at ./app/build.gradle and ./gradlew should be directly in the project_location. If your project has a traditional structure, the default value should be correct.|
-
 | iOS | ios_archive_path | `$BITRISE_XCARCHIVE_PATH` | Path to either the IPA file or the xcarchive directory (not a zip file). |
 | iOS | ios_dsyms_dir_path | `$BITRISE_DSYM_DIR_PATH` | Path to the dSYMs directory. Useful when the archive does not contain debug symbols. |
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Upload build to AppSweep
 
-The step uploads a release or debug build to [AppSweep](https://appsweep.guardsquare.com) for security scanning. It supports iOS and Android apps.
-
-The AppSweep Gradle plugin is used to upload your Android app, while the [Guardsquare CLI](https://appsweep.guardsquare.com/docs/ci/guardsquare-cli) is used for iOS.
+The step uploads a built app to [AppSweep](https://appsweep.guardsquare.com) for security scanning. It supports iOS and Android apps, and uses the [Guardsquare CLI](https://appsweep.guardsquare.com/docs/ci/guardsquare-cli) to upload the app
 
 ## How to use this Step
 
@@ -11,21 +9,9 @@ Alternatively, you can run it with the [bitrise CLI](https://github.com/bitrise-
 
 The `APPSWEEP_API_KEY` variable must be set. You can generate it in the API Keys section of your project settings on the [AppSweep website](https://appsweep.guardsquare.com/) . This key **SHOULD NOT** be checked into your repository, but set up as a [Bitrise Secret](https://devcenter.bitrise.io/en/builds/secrets.html).
 
-See below for the platform-specific configuration.
+Add this step after the build phase and the app will be uploaded. No further configuration is needed when using the default bitrise build steps. 
 
-### Android
-
-To use this step, you need:
-
-* A [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) in your project. It is expected in the root folder.
-* The Gradle AppSweep plugin. If you have a common folder structure (in particular `./app/build.gradle` is your app's gradle file) then the plugin will be injected automatically. Otherwise you need to add the AppSweep plugin manually, by adding `id "com.guardsquare.appsweep" version "latest.release"` to the plugin section of your app's build.gradle script.
-* By default, the `release` build will be scanned. If you want to change this, set `build_variant` to the desired variant in your step's configuration.
-
-### iOS
-
-Add this step after the build phase and the archive will be uploaded. No further configuration is needed when using the default bitrise build steps. 
-
-If necessary, you can override the parameters of the step. In this case, make sure that the path to the debug symbols is set correctly to obtain detailed analysis results.
+If necessary, you can override the parameters of the step. In this case, make sure that the path to the mapping file (Android) and debug symbols (iOS) is set correctly to obtain detailed analysis results.
 
 ## Configuration
 
@@ -33,9 +19,10 @@ The step can either be configured directly in the `bitrise.yml`, or in the visua
 | Platform | Parameter         | Default     | Description |
 |----------|-------------------|-------------|-------------|
 | both | appsweep_api_key| `APPSWEEP_API_KEY` secret key | Must be set to allow scanning of the app inside an AppSweep project. You can generate it in the API Keys section of your project settings in the AppSweep UI.| 
-| Android | build_variant | release | Set to the desired build variant name for variants other than `release`. |
-| Android | project_location | `$PROJECT_LOCATION` | Set this to the location of your project inside your repository. Inside this directory, the build file should be accesible via path ./app/build.gradle and ./gradlew should be directly in the project_location. If your project has a traditional structure, the default value should be correct.|
-| Android | gradle_plugin_version | `1.0.0` | Set to particular numerical value or to `latest.release` (requires at least Gradle 7). If the plugin is already configured in your repository then this option has no impact.|
+| Android | android_app_path | `$BITRISE_APK_PATH` | Path name to the built Android app. Can be an Android apk / aab. |
+| Android | android_mappingfile_path | `$BITRISE_MAPPING_PATH` | Path to the obfuscation mapping file. E.g., ./app/build/outputs/mapping/debug/mapping.txt |
+| Android | android_project_location | `$PROJECT_LOCATION` | Set this to the location of your project inside your repository. Inside this directory, the build file should be accesible at ./app/build.gradle and ./gradlew should be directly in the project_location. If your project has a traditional structure, the default value should be correct.|
+
 | iOS | ios_archive_path | `$BITRISE_XCARCHIVE_PATH` | Path to either the IPA file or the xcarchive directory (not a zip file). |
 | iOS | ios_dsyms_dir_path | `$BITRISE_DSYM_DIR_PATH` | Path to the dSYMs directory. Useful when the archive does not contain debug symbols. |
 
@@ -43,15 +30,9 @@ The step can either be configured directly in the `bitrise.yml`, or in the visua
 
 ```
 - git::https://github.com/Guardsquare/bitrise-step-scan-with-appsweep.git@main:
-    title: AppSweep
-    inputs:
-    - build_variant: debug
+    title: AppSweep Scan
 ```
 
 ### Troubleshooting 
-
-If the step fails because of **Task was not found in root project** it means that the plugin was not injected properly. Please add the gradle plugin manually to `build.gradle`. 
-
-If the step fails with **The gradlew wrapper was not found. Please provide the correct project_location** that means that path to gradlew is not correct. Please remember that, the `project_location` must be point to the root of the repository which should contain `gradlew`.
 
 If the step fails with **Required input APPSWEEP_API_KEY is empty** it means that AppSweep API key was not set. It can be set up as a [Bitrise Secret](https://devcenter.bitrise.io/en/builds/secrets.html), as an input or it can be exported as environmental variable. 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: scan-with-appsweep
-  - BITRISE_STEP_VERSION: "2.0.2"
+  - BITRISE_STEP_VERSION: "3.0.0"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
 

--- a/step.sh
+++ b/step.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -exo pipefail
 
-export APPSWEEP_API_KEY=${appsweep_api_key}
-export IOS_ARCHIVE_PATH=${ios_archive_path}
-export IOS_DSYMS_DIR_PATH=${ios_dsyms_dir_path}
+APPSWEEP_API_KEY=${appsweep_api_key}
+APP_PATH=${android_app_path}
+
+if [ -z "$APP_PATH" ]; then
+	APP_PATH=${ios_archive_path}
+fi
 
 if [ -z "$APPSWEEP_API_KEY" ]
 then
@@ -11,80 +14,32 @@ then
 	exit 1
 fi
 
-# iOS
-if [ -e  "$IOS_ARCHIVE_PATH" ]; then
-	if [ -e  "$IOS_ARCHIVE_PATH" ]; then
-		APPSWEEP_CLI_DIR=$(mktemp -d)
-		curl --retry 3 \
-			--retry-max-time 120 \
-			--retry-all-errors \
-			-sS https://platform.guardsquare.com/cli/install.sh \
-			| sh -s -- --yes --bin-dir "$APPSWEEP_CLI_DIR"
+if [ -e  "$APP_PATH" ] ; then
+	APPSWEEP_CLI_DIR=$(mktemp -d)
+	curl --retry 3 \
+		--retry-max-time 120 \
+		--retry-all-errors \
+		-sS https://platform.guardsquare.com/cli/install.sh \
+		| sh -s -- --yes --bin-dir "$APPSWEEP_CLI_DIR"
 
-		if [ -d "$IOS_DSYMS_DIR_PATH" ]; then
-			DSYMS_FLAG="--dsym $IOS_DSYMS_DIR_PATH"
-		fi
-
-		url=$("$APPSWEEP_CLI_DIR/guardsquare" scan "$IOS_ARCHIVE_PATH" $DSYMS_FLAG --format '{{.URL}}')
-
-		echo "APPSWEEP_UPLOAD_URL=$url"
-		envman add --key APPSWEEP_UPLOAD_URL --value $url
-		exit 0
+	if [ -d "${ios_dsyms_dir_path}" ]; then
+		DSYMS_FLAG="--dsym ${ios_dsyms_dir_path}"
+	fi
+	if [ -e "${android_mappingfile_path}" ]; then
+		MAPPING_FLAG="--mapping-file ${android_mappingfile_path}_DIR_PATH"
+	fi
+	if [ -n "${commit_hash}" ]; then
+		COMMIT_FLAG="--commit-hash ${commit_hash}"
+	fi
+	if [ -d "${android_project_location}" ]; then
+		PROJECTDIR_FLAG="--project-dir ${android_project_location}"
 	fi
 
-	echo "The iOS archive path at '$IOS_ARCHIVE_PATH' could not be found."
+	url=$($APPSWEEP_CLI_DIR/guardsquare scan $APP_PATH $DSYMS_FLAG $MAPPING_FLAG $COMMIT_FLAG $PROJECTDIR_FLAG --format '{{.URL}}')
+
+	echo "You can view your scan results at $url"
+	envman add --key APPSWEEP_UPLOAD_URL --value $url
+else
+	echo "Input file $APP_PATH does not exist"
 	exit 1
 fi
-
-# Gradle/Android
-cd ${project_location}
-BUILD_FILE=./app/build.gradle
-
-if [ ! -f "$BUILD_FILE" ]; then
-    echo "$BUILD_FILE does not exist. Probably you are using not standard project structure, please add \"com.guardsquare.appsweep\" to the plugin section of your app's build.gradle script."
-else
-	if grep -Fq "\"com.guardsquare.appsweep\"" $BUILD_FILE
-	then
-		echo "AppSweep plugin already exists in $BUILD_FILE. Not injecting."
-	else
-		echo "AppSweep plugin was not found in $BUILD_FILE. Injecting..."
-		#remove all white lines
-		sed -i '/^[[:space:]]*$/d' $BUILD_FILE
-		#remove potential new line characters after 'plugins'
-		sed -i '/plugins/{N;s/\n//;}' $BUILD_FILE
-		#inject AppSweep plugin
-		sed -i "s/plugins\s*{/plugins\n{\n\tid \"com.guardsquare.appsweep\" version \"${gradle_plugin_version}\"\n/1" $BUILD_FILE
-		if grep -Fq "\"com.guardsquare.appsweep\"" $BUILD_FILE
-		then
-			echo "AppSweep plugin succesfully injected to $BUILD_FILE."
-		else
-			echo "AppSweep plugin was not injected to $BUILD_FILE. Please add \"com.guardsquare.appsweep\" to the plugin section of your app's build.gradle script."
-		fi   
-	fi
-fi
-
-if [ -f "./gradlew" ];
-then
-	echo "The gradlew wrapper was found in ${project_location}/gradlew"
-	GRADLEW=./gradlew
-else
-	echo "The gradlew wrapper was not found. Please provide the correct project_location."
-	exit 1
-fi
-
-basename="uploadToAppSweep"
-if [ -z "${build_variant}" ];
-then
-  # Build variant absent, we default to release
-  output=$($GRADLEW "${basename}Release")
-else
-  # Capitalize first letter of variant name, concatenate with Gradle task basename
-  capitalized="$(echo ${build_variant} | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')"
-  output=$($GRADLEW "$basename$capitalized")
-fi
-
-url=$(echo $output | grep 'Your scan results will be available at' | sed 's/.*Your scan results will be available at //')
-
-envman add --key APPSWEEP_UPLOAD_URL --value $url
-echo "APPSWEEP_UPLOAD_URL=$url"
-

--- a/step.yml
+++ b/step.yml
@@ -1,6 +1,7 @@
 title: AppSweep Mobile Security Testing
 summary: Scan your app using Guardsquare's mobile application security testing tool AppSweep
-description: "The build of your app is automatically uploaded to [AppSweep](https://appsweep.guardsquare.com)
+description: "The build of your Android or iOS app is automatically uploaded to 
+  [AppSweep](https://appsweep.guardsquare.com)
   for scanning. \n\nAppSweep is Guardsquare's free tool enabling developers to put
   mobile security at the forefront of app development. AppSweep helps you identify
   and fix security issues in your code and dependencies with actionable recommendations
@@ -8,43 +9,51 @@ description: "The build of your app is automatically uploaded to [AppSweep](http
 website: https://www.guardsquare.com/appsweep-mobile-application-security-testing
 source_code_url: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep
 support_url: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep/issues
-published_at: 2022-01-19T13:15:42.006047158+01:00
-source:
-  git: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep.git
-  commit: 74d0913911c69563ddb08b86887fbbce721c1745
+
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
+
 project_type_tags:
 - android
 - ios
+
 type_tags:
 - test
+
 toolkit:
   bash:
     entry_file: step.sh
+
 deps:
   apt_get:
   - name: curl
   brew:
   - name: curl
+
 is_requires_admin_user: false
 is_always_run: false
 is_skippable: true
+
 inputs:
 - appsweep_api_key: $APPSWEEP_API_KEY
   opts:
     description: |
-      An `APPSWEEP_API_KEY` must be set to allow scanning of the app inside an AppSweep project. You can generate it in the API Keys section of your project settings.
+      An `APPSWEEP_API_KEY` must be set to allow scanning of the app inside an AppSweep project. You can generate it in the API Keys section of your app settings inside AppSweep.
     is_required: true
     is_sensitive: true
     title: AppSweep API key
+- commit_hash: $GIT_CLONE_COMMIT_HASH
+  opts:
+    description: |
+      The commit for this build. This commit will be associated with the app scan.
+    title: Git commit hash
 - ios_archive_path: $BITRISE_XCARCHIVE_PATH
   opts:
     description: |
       AppSweep works with both, an IPA file or an xcarchive directory. This has to be set if you want to analyze iOS builds.
     is_required: false
-    title: The path of the iOS archive (IPA file or xcarchive directory)
+    title: The path of the iOS archive
     category: "iOS"
 - ios_dsyms_dir_path: $BITRISE_DSYM_DIR_PATH
   opts:
@@ -53,26 +62,25 @@ inputs:
     is_required: false
     title: The path of the dSYM directory.
     category: "iOS"
-- build_variant: release
+- android_app_path: $BITRISE_APK_PATH
   opts:
     description: |
-      Set to the desired build variant, e.g. `debug`. By default, the `release` variant will be uploaded.
+      Path name to the built app. Can be an Android apk / aab.
     is_required: false
-    title: Select the build variant which should be uploaded
+    title: The path of the Android app
+- android_mappingfile_path:
+  opts:
+    description: |
+      Path to the obfuscation mapping file. E.g., ./app/build/outputs/mapping/debug/mapping.txt
+    is_required: false
+    title: The path to the obfuscation mapping file 
     category: "Android"
-- project_location: $PROJECT_LOCATION
+- android_project_location: $PROJECT_LOCATION
   opts:
     description: |
       Set this to the location of your project inside your repository. Inside this directory, the build file should be `./app/build.gradle` and `gradlew` should be directly in the `project_location`.
     is_required: false
     title: Project file path
-    category: "Android"
-- gradle_plugin_version: 1.0.0
-  opts:
-    description: |
-      The version of AppSweep gradle plugin. Can be set to particular numerical value or to `latest.release`, which requires at least Gradle 7.
-    is_required: true
-    title: AppSweep gradle plugin version
     category: "Android"
 outputs:
 - APPSWEEP_UPLOAD_URL: null


### PR DESCRIPTION
Simplifies the Android upload by not depending on the deprecated Gradle plugin, but using the CLI.